### PR TITLE
refactor: PIZ10 correct CI job and create template for pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+#### 🤔 Why?
+
+Summarize why you're making these changes
+
+#### 🛠 What I changed:
+
+List out what you changed in simple English, using bullet points
+
+#### 🗃️ Trello Issues:
+
+List of Trello issue links
+
+For example: [PIZXX - Some Issue](https://trello.com)

--- a/.github/workflows/CI_tests.yml
+++ b/.github/workflows/CI_tests.yml
@@ -1,22 +1,21 @@
 name: CI test coverage
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        python-version: [3.x]
-
     steps:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
 
       - name: Source Virtualenv
         run: |
@@ -25,10 +24,7 @@ jobs:
           source venv/bin/activate
 
       - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Run tests
-        run: |
-          export PYTHONPATH=src
-          python3 manage.py test
+        run: python3 manage.py test


### PR DESCRIPTION
#### 🤔 Why?
There is an error when the GitHub CI job is executed to run the tests, so this error needs to be fixed in the process. Also, whenever we want to make a new PR, we need to write the whole PR structure from scratch, that's why we need to have a template with all this structure pre-defined.

#### 🛠 What I changed:
- .github/pull_request_template.md ***Setting up a template for each time a new PR is created***
- .github/workflows/CI_tests.yml ***Fixing error in the GitHub CI job flow***

#### 🗃️ Trello Issues:
[PIZ10 - Refactor CI job with GitHub](https://trello.com/c/rXDksTHi)